### PR TITLE
【フロント調整】TopMenu画面のUI改善

### DIFF
--- a/src/TopMenu.css
+++ b/src/TopMenu.css
@@ -24,6 +24,28 @@
   z-index: 10;
 }
 
+/* 横並びで全体幅を他のTextFieldと揃える */
+.nickname-form {
+  display: flex;
+  width: 100%;
+  background: #7f9be4; /* カード色 */ /* ← これで520px幅に揃う */
+  gap: 8px;
+}
+
+/* 入力欄を残り幅いっぱいに広げる */
+.nickname-input {
+  flex: 1;
+}
+
+/* ボタンは固定幅 */
+.nickname-btn {
+  height: 56px; /* TextFieldと揃える */
+  min-width: 96px; /* 送信ボタンの幅 */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .create-room-btn {
   min-width: 120px;
   height: 56px; /* ← MUIのTextFieldと同じ高さ */
@@ -48,6 +70,18 @@
 .topmenu-form-box .MuiOutlinedInput-root {
   background: #f5f5f5; /* ← Formのinput背景に近い薄いグレー */
   border-radius: 6px;
+}
+
+.room-join-btn {
+  display: flex;
+  justify-content: space-between; /* 左右に分散 */
+  padding: 12px 20px; /* 内側の余白を増やす */
+  font-size: 16px; /* 少し大きめに */
+}
+.room-join-btn span {
+  display: flex;
+  align-items: center;
+  gap: 6px; /* 部屋名と人数の間に隙間 */
 }
 
 /* ラベルや文字色は濃い目に戻す */

--- a/src/TopMenu.tsx
+++ b/src/TopMenu.tsx
@@ -261,9 +261,9 @@ const TopMenu: React.FC = () => {
                 variant="outlined"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                inputProps={{ maxLength: 40, "aria-label": "nickname" }}
                 fullWidth
-                className="nickname-input"
+                className="nickname-input" // ← 横並び用に伸縮させる
+                inputProps={{ maxLength: 40, "aria-label": "nickname" }}
               />
               <Button
                 type="submit"
@@ -352,7 +352,7 @@ const TopMenu: React.FC = () => {
                     className="childanswer-btn btn-outlined room-join-btn"
                   >
                     <span>
-                      room name: <b>{r.room_name}</b>
+                      部屋名: <b>{r.room_name}</b>
                     </span>
                     <span>
                       人数: <b>{r.num_of_nowusers ?? 0}</b>


### PR DESCRIPTION
**概要**
・Top Menuの画面を綺麗にしました
・必要最小限の情報に絞ることとできるだけコンポーネントを活用することを意識しました
・入力欄が狭いことや文字以外の入力形態を含むので、コンポーネントのスタイルを適用する形で調整して書きました

**変更詳細**
<img width="903" height="779" alt="image" src="https://github.com/user-attachments/assets/371ecfc4-ac63-44eb-91ae-770254d4c017" />